### PR TITLE
Improved numerical differentiation matrixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # mac stuff
 .DS_Store
+
+# testing scripts
+testing/

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .secsy import utils 
+from .secsy import utils, diffutils
 from .secsy.utils import get_SECS_J_G_matrices, get_SECS_B_G_matrices
 from .secsy import spherical
 from .secsy.cubedsphere import CSgrid, CSprojection

--- a/secsy/diffutils.py
+++ b/secsy/diffutils.py
@@ -1,0 +1,71 @@
+""" 
+diffutils
+
+"""
+
+import numpy as np
+from scipy.special import factorial
+from fractions import Fraction
+
+
+def lcm_arr(arr):
+    """ Calculate least common multiplier for array of integers
+    """
+    result = np.lcm(arr[0], arr[1])
+    for i in range(2, len(arr)-1):
+        result = np.lcm(result, arr[i])
+
+    return result
+
+
+def stencil(evaluation_points, order = 1, h = 1, fraction = False):
+    """ 
+    Calculate stencil for finite difference calculation of derivative
+
+    Parameters
+    ----------
+    evaluation_points: array_like
+        evaluation points in regular grid. e.g. [-1, 0, 1] for 
+        central difference or [-1, 0] for backward difference
+    order: integer, optional
+        order of the derivative. Default 1 (first order)
+    h: scalar, optional
+        Step size. Default 1
+    fraction: bool, optional
+        Set to True to return coefficients as integer numerators
+        and a common denomenator. Be careful with this if you use
+        a very large number of evaluation points...
+
+    Returns
+    -------
+    coefficients: array
+        array of coefficients in stencil. Unless fraction is set 
+        to True - in which case a tuple will be returned with
+        an array of numerators and an integer denominator. If 
+        fraction is True, h is ignored - and you should multiply the 
+        denominator by h**order to get the coefficients
+
+    Note
+    ----
+    Algorithm from Finte Difference Coefficient Calculator
+    (https://web.media.mit.edu/~crtaylor/calculator.html)
+    """
+
+    # calculate coefficients:
+    evaluation_points = np.array(evaluation_points).flatten().reshape((1, -1))
+    p = np.arange(evaluation_points.size).reshape((-1, 1))
+    d = np.zeros(evaluation_points.size)
+    d[order] = factorial(order)
+
+    coeffs = np.linalg.inv(evaluation_points**p).dot(d)
+
+    if fraction:
+        # format nicely:
+        fracs = [Fraction(c).limit_denominator() for c in coeffs]
+        denominators = [c.denominator for c in fracs]
+        numerators   = [c.numerator for c in fracs]
+        cd = lcm_arr(denominators)
+        numerators = [int(c * cd / a) for (c, a) in zip(numerators, denominators)]
+        return (numerators, cd)
+    else:
+        return coeffs / h ** order

--- a/secsy/utils.py
+++ b/secsy/utils.py
@@ -1,11 +1,5 @@
 """ 
-
-Functions:
-----------
-get_theta
-get_SECS_J_G_matrices
-get_SECS_B_G_matrices
-
+SECS utils
 
 """
 

--- a/test_scripts/cubedsphere_divergence_test.py
+++ b/test_scripts/cubedsphere_divergence_test.py
@@ -1,0 +1,57 @@
+""" Test numerical calculation of divergence in cubed sphere coords
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+from secsy import CSgrid, CSprojection
+
+d2r = np.pi / 180
+
+lat0, lon0 = 60., 150. # center of projection
+e, n = -3, -10. # orientation of projection in east/north
+
+N, M = 25, 25 # SH degree and order of the spherical harmonic used for testing
+
+projection = CSprojection((lon0, lat0), (e, n))
+grid = CSgrid(projection, 3000, 2000, 5., 5.)
+shape = grid.lat.shape
+ph = grid.lon * np.pi / 180
+th = (90 - grid.lat) * np.pi / 180
+
+# Calculate SH derivatives (components) and divergence
+P = np.cos(N * 2 * th) - 1
+dP  = -N * 2 * np.sin(N * 2 * th)
+dP2 = -N**2 * 4 * np.cos(N * 2 * th)
+Y     = P  * (np.cos(M * ph) + np.sin(M * ph))
+dYdth = dP * (np.cos(M * ph) + np.sin(M * ph))
+dYdph = P * M * (np.cos(M * ph) - np.sin(M * ph))
+
+div_analytic = -(np.cos(M * ph) + np.sin(M * ph)) / (np.sin(th) * grid.R**2) * \
+                   ( (2 * N * np.sin(2 * N * th)*np.cos(th) + 4 * N**2 * np.sin(th) * np.cos(2 * N * th)) +
+                      M**2 * (np.cos(2 * N * th) - 1) / np.sin(th)
+                   )
+
+
+je =  dYdph / np.sin(th) / grid.R
+jn = -dYdth              / grid.R
+j = np.vstack((je.flatten().reshape((-1, 1)), jn.flatten().reshape((-1, 1))))
+
+
+# calcualte divergence numerically:
+D = grid.divergence(S = 1)
+div_num = D.dot(j).reshape(shape)
+
+# plot comparison
+fig, axs = plt.subplots(ncols = 3, figsize = (10, 5))
+axs[0].contourf(grid.xi, grid.eta, div_analytic)
+axs[0].set_title('Divergence analytic')
+axs[1].contourf(grid.xi, grid.eta, div_num)
+axs[1].set_title('Divergence numerical')
+axs[2].scatter(div_analytic.flatten(), div_num.flatten())
+axs[2].set_xlabel('analytic')
+axs[2].set_ylabel('numerical')
+
+plt.ion()
+plt.show()
+plt.pause(0.001)
+
+

--- a/test_scripts/cubedsphere_partial_derivative_test.py
+++ b/test_scripts/cubedsphere_partial_derivative_test.py
@@ -1,0 +1,103 @@
+""" 
+Test numerical calculation of gradient components in cubed sphere coordinates
+"""
+import numpy as np
+from secsy import CSgrid, CSprojection
+import matplotlib.pyplot as plt
+
+N, M = 4, 4 # SH degree and order of the spherical harmonic used for testing
+
+### SET UP CUBED SPHERE GRID AND PROJECTION
+position, orientation = (0, 40), (1, -1)
+projection = CSprojection(position, orientation)
+grid = CSgrid(projection, 5000, 5000, 5., 10., R = 1000)
+shape = grid.lat.shape
+ph = grid.lon * np.pi / 180
+th = (90 - grid.lat) * np.pi / 180
+Lxi, Leta = grid.get_Le_Ln(S = 3, return_dxi_deta = True)
+Le, Ln = grid.get_Le_Ln(S = 3)
+
+###### CARTESIAN FUNCTION ################
+##########################################
+z = np.sin(N * grid.xi) * np.cos(M*grid.eta) + (5*grid.xi)**5
+dzdxi = N * np.cos(M*grid.eta) * np.cos(M * grid.xi) + 5 * (5 * grid.xi)**4 * 5
+dzdet = -M*np.sin(N * grid.xi) * np.sin(N*grid.eta)
+
+
+fig = plt.figure(figsize = (15,10))
+axz  = fig.add_subplot(231)
+ax_dzdxi_true  = fig.add_subplot(232)
+ax_dzdxi_est   = fig.add_subplot(235)
+ax_dzdet_true  = fig.add_subplot(233)
+ax_dzdet_est   = fig.add_subplot(236)
+ax_sc = fig.add_subplot(234)
+
+axz.contourf(grid.xi, grid.eta, z)
+_ = ax_dzdet_true.contourf(grid.xi, grid.eta, dzdet)
+ax_dzdet_est.contourf(grid.xi, grid.eta, Leta.dot(z.flatten()).reshape(grid.shape))#, levels = _.levels)
+_ = ax_dzdxi_true.contourf(grid.xi, grid.eta, dzdxi)
+ax_dzdxi_est.contourf(grid.xi, grid.eta, Lxi.dot(z.flatten()).reshape(grid.shape))#, levels = _.levels)
+
+ax_sc.scatter(Lxi.dot(z.flatten()), dzdxi, c = 'C0')
+ax_sc.scatter(Leta.dot(z.flatten()), dzdet, c = 'C1')
+ax_sc.plot(ax_sc.get_xlim(), ax_sc.get_xlim())
+
+
+####### SPHERICAL FUNCTION ###############
+##########################################
+P = np.cos(N * 2 * th) - 1
+dP = -N * 2 * np.sin(N * 2 * th)
+
+Y     = P  * (np.cos(M * ph) + np.sin(M * ph))
+dYdth = dP * (np.cos(M * ph) + np.sin(M * ph))
+dYdph = P * M * (np.cos(M * ph) - np.sin(M * ph))
+
+gradY_e =  dYdph / np.sin(th) / grid.R
+gradY_n = -dYdth              / grid.R
+
+### PLOT THE COMPARISON
+fig = plt.figure(figsize = (15,10))
+axY  = fig.add_subplot(131)
+ax_gradY_e_true  = fig.add_subplot(232)
+ax_gradY_e_est   = fig.add_subplot(235)
+ax_gradY_n_true  = fig.add_subplot(233)
+ax_gradY_n_est   = fig.add_subplot(236)
+
+axY.contourf(grid.xi, grid.eta, Y)
+
+
+
+_ = ax_gradY_e_true.contourf(grid.xi, grid.eta, gradY_e)
+ax_gradY_e_est .contourf(grid.xi, grid.eta, Le.dot(Y.flatten()).reshape(shape), levels = _.levels)
+_ = ax_gradY_n_true.contourf(grid.xi, grid.eta, gradY_n)
+ax_gradY_n_est .contourf(grid.xi, grid.eta, Ln.dot(Y.flatten()).reshape(shape), levels = _.levels)
+
+
+
+for ax in [axY, ax_gradY_e_est, ax_gradY_e_true, ax_gradY_n_est, ax_gradY_n_true]:
+    xlim, ylim = ax.get_xlim(), ax.get_ylim()
+    for lat in np.r_[-80:81:10]:
+        x, y = projection.geo2cube(np.arange(361), np.ones(361) * lat)
+        ax.plot(x, y, 'k:')
+    for lon in np.r_[0:361:15]:
+        x, y = projection.geo2cube(np.ones(180) * lon, np.linspace(-80, 80, 180))
+        ax.plot(x, y, 'k:')
+    ax.set_xlim(*xlim)
+    ax.set_ylim(*ylim)
+    ax.set_aspect('equal')
+
+
+axY.set_title('Scalar field')
+ax_gradY_e_true.set_title('Eastward gradient \nexact (top) and estimated (bottom)')
+ax_gradY_n_true.set_title('Northward gradient \nexact (top) and estimated (bottom)')
+
+
+fig = plt.figure()
+ax = fig.add_subplot(111)
+ax.scatter(Ln.dot(Y.flatten()), gradY_n, c = 'C0')
+ax.scatter(Le.dot(Y.flatten()), gradY_e, c = 'C1')
+ax.plot(ax.get_xlim(), ax.get_xlim())
+
+plt.ion()
+plt.show()
+plt.pause(0.001)


### PR DESCRIPTION
Major improvement to the matrices that calculate divergence and gradients:

- Matrices are now sparse, using the scipy.sparse module. This means that much less memory is used. That means that larger grids can be used, and that calculations are faster.
- Differentiation can now be performed with a stencil of arbitrary size
- Fixed a bug in the gradient calculation which seems to have caused some small errors in the northward component of the gradient